### PR TITLE
Fix the "Could not find com.android.tools.build:gradle:2.2.0" gradle error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
@@ -14,6 +14,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }


### PR DESCRIPTION
Fix the "Could not find com.android.tools.build:gradle:2.2.0" gradle error on a fresh git clone