### PR TITLE
Do not insert twice the `Content-Type` HTTP header

### DIFF
--- a/app/src/main/java/net/yupol/transmissionremote/app/transport/request/Request.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/transport/request/Request.java
@@ -80,7 +80,6 @@ public abstract class Request<RESULT> extends GoogleHttpClientSpiceRequest<RESUL
         request.setNumberOfRetries(0);
 
         HttpHeaders headers = new HttpHeaders()
-                .setContentType("json")
                 .set(HEADER_SESSION_ID, Strings.emptyToNull(server.getLastSessionId()));
         if (server.isAuthenticationEnabled()) {
             headers.setBasicAuthentication(server.getUserName(), server.getPassword());


### PR DESCRIPTION
A little back-story here.
I noticed that TransmissionRemote was failing to connect to a Transmission server proxied behind a `lighttpd` instance.
I investigated the problem and discovered that it was receiving a 400 Bad Request response to each request, because the `Content-Type` header was being set twice (to `json` and to `application/json`).

By reading the HTTP RFC it seems that it SHOULD be specified only once, so it seems reasonable to leave the `application/json` type.