### PR TITLE
Add udp support when adding trackers

### DIFF
--- a/app/src/main/java/net/yupol/transmissionremote/app/torrentdetails/TrackerUrlDialog.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/torrentdetails/TrackerUrlDialog.java
@@ -107,7 +107,7 @@ public class TrackerUrlDialog extends DialogFragment {
 
         if (url.isEmpty()) return "";
 
-        if (url.startsWith("http://") || url.startsWith("https://")) {
+        if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("udp://")) {
             return url;
         } else {
             return "http://" + url;


### PR DESCRIPTION
For issue #78. I don't know how to compile Android apps, so I can't test this to verify, but it looks like it should work.
Regarding the displaying of trackers incorrectly within the app itself, that would need to be addressed separately.