### PR TITLE
Mark all currently downloading torrents as active

### DIFF
--- a/app/src/main/java/net/yupol/transmissionremote/app/model/json/Torrent.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/model/json/Torrent.java
@@ -124,7 +124,8 @@ public class Torrent implements ID, Parcelable {
         return peersGettingFromUs > 0
                 || peersSendingToUs > 0
                 || webseedsSendingToUs > 0
-                || isChecking();
+                || isChecking()
+                || isDownloading();
     }
 
     public boolean isChecking() {


### PR DESCRIPTION
* According to transmission-remote-gtk source code
  TORRENT_FLAG_ACTIVE should be set unconditionally.
* See : https://github.com/transmission-remote-gtk/transmission-remote-gtk/blob/810d589/src/torrent.c#L272