### PR TITLE
Make torrent detail text values selectable

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,6 +74,7 @@
     <style name="InfoPageSecondColumnStyle">
         <item name="android:textSize">@dimen/tr_abc_text_size_body_1_material</item>
         <item name="android:textColor">?android:attr/textColorPrimary</item>
+        <item name="android:textIsSelectable">true</item>
     </style>
 
     <style name="InfoPageTitleStyle">


### PR DESCRIPTION
Make torrent details selectable so users can copy text values from existing torrents.

Mainly useful to copy existing torrent location to paste same value for new torrent(s) being added.