### PR TITLE
Add a stats view similar to transmission-web

### DIFF
--- a/app/src/main/java/net/yupol/transmissionremote/app/MainActivity.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/MainActivity.java
@@ -137,6 +137,7 @@ public class MainActivity extends BaseSpiceActivity implements TorrentUpdater.To
     private static final String TAG_OPEN_TORRENT_DIALOG = "tag_open_torrent_dialog";
     private static final String TAG_OPEN_TORRENT_BY_ADDRESS_DIALOG = "tag_open_torrent_by_address_dialog";
     private static final String TAG_DOWNLOAD_LOCATION_DIALOG = "tag_download_location_dialog";
+    private static final String TAG_SERVER_STATS_DIALOG = "tag_server_stats_dialog";
 
     private static final String MIME_TYPE_TORRENT = "application/x-bittorrent";
     private static final String SCHEME_MAGNET = "magnet";
@@ -762,6 +763,8 @@ public class MainActivity extends BaseSpiceActivity implements TorrentUpdater.To
             case R.id.action_pause_all_torrents:
                 pauseAllTorrents();
                 return true;
+            case R.id.action_open_stats:
+                new StatsDialogFragment().show(getSupportFragmentManager(), TAG_SERVER_STATS_DIALOG);
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/net/yupol/transmissionremote/app/StatsDialogFragment.kt
+++ b/app/src/main/java/net/yupol/transmissionremote/app/StatsDialogFragment.kt
@@ -1,0 +1,63 @@
+package net.yupol.transmissionremote.app
+
+import android.app.Dialog
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AlertDialog
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import com.octo.android.robospice.persistence.exception.SpiceException
+import com.octo.android.robospice.request.listener.RequestListener
+import net.yupol.transmissionremote.app.databinding.StatsBinding
+import net.yupol.transmissionremote.app.model.json.ServerStats
+import net.yupol.transmissionremote.app.opentorrent.DownloadLocationDialogFragment
+import net.yupol.transmissionremote.app.transport.BaseSpiceActivity
+import net.yupol.transmissionremote.app.transport.TransportManager
+import net.yupol.transmissionremote.app.transport.request.StatsGetRequest
+import android.text.format.Formatter
+
+class StatsDialogFragment : DialogFragment() {
+
+    private val TAG: String = StatsDialogFragment::class.java.simpleName
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        return activity?.let {
+            val builder = AlertDialog.Builder(it)
+            val inflater = requireActivity().layoutInflater
+            val binding = DataBindingUtil.inflate<StatsBinding>(inflater, R.layout.stats, null, false)
+            binding.loadingInProgress = true
+
+            builder.setView(binding.root)
+                .setNegativeButton(R.string.material_drawer_close,
+                    {dialog, id -> getDialog()?.cancel()})
+
+            getTransportManager().doRequest(StatsGetRequest(), object : RequestListener<ServerStats> {
+                override fun onRequestFailure(spiceException: SpiceException?) {
+                    Log.e(TAG, "error fetching server stats")
+                }
+
+                override fun onRequestSuccess(result: ServerStats?) {
+                    binding.statsTotalUploaded.text =
+                            Formatter.formatFileSize(it, result?.cumulativeStats?.uploadedBytes?: 0)
+                    binding.statsTotalDownloaded.text =
+                        Formatter.formatFileSize(it, result?.cumulativeStats?.downloadedBytes?: 0)
+
+                    binding.statsSessionUploaded.text =
+                        Formatter.formatFileSize(it, result?.currentStats?.uploadedBytes?: 0)
+                    binding.statsSessionDownloaded.text =
+                        Formatter.formatFileSize(it, result?.currentStats?.downloadedBytes?: 0)
+
+                    binding.loadingInProgress = false
+                }
+
+            })
+
+            builder.create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
+
+    private fun getTransportManager(): TransportManager {
+        return (activity as BaseSpiceActivity).getTransportManager()
+    }
+}

--- a/app/src/main/java/net/yupol/transmissionremote/app/model/json/ServerStats.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/model/json/ServerStats.java
@@ -1,0 +1,8 @@
+package net.yupol.transmissionremote.app.model.json;
+
+import com.google.api.client.util.Key;
+
+public class ServerStats {
+    @Key("cumulative-stats") public TransferStats cumulativeStats;
+    @Key("current-stats") public TransferStats currentStats;
+}

--- a/app/src/main/java/net/yupol/transmissionremote/app/model/json/TransferStats.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/model/json/TransferStats.java
@@ -1,0 +1,22 @@
+package net.yupol.transmissionremote.app.model.json;
+
+import com.google.api.client.util.Key;
+
+public class TransferStats {
+
+    @Key private long downloadedBytes;
+    @Key private long secondActive;
+    @Key private long uploadedBytes;
+
+    public long getDownloadedBytes() {
+        return downloadedBytes;
+    }
+
+    public long getUploadedBytes() {
+        return uploadedBytes;
+    }
+
+    public long getSecondActive() {
+        return secondActive;
+    }
+}

--- a/app/src/main/java/net/yupol/transmissionremote/app/transport/request/StatsGetRequest.java
+++ b/app/src/main/java/net/yupol/transmissionremote/app/transport/request/StatsGetRequest.java
@@ -1,0 +1,20 @@
+package net.yupol.transmissionremote.app.transport.request;
+
+import net.yupol.transmissionremote.app.model.json.ServerSettings;
+import net.yupol.transmissionremote.app.model.json.ServerStats;
+
+import org.json.JSONObject;
+
+public class StatsGetRequest extends Request<ServerStats>{
+    public StatsGetRequest() { super(ServerStats.class); }
+
+    @Override
+    protected String getMethod() {
+        return "session-stats";
+    }
+
+    @Override
+    protected JSONObject getArguments() {
+        return null;
+    }
+}

--- a/app/src/main/res/layout/stats.xml
+++ b/app/src/main/res/layout/stats.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+        <import type="android.view.View" />
+        <variable
+            name="loadingInProgress"
+            type="boolean" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp"
+            android:orientation="vertical"
+            android:visibility="@{loadingInProgress ? View.GONE : View.VISIBLE}">
+
+            <TextView
+                android:id="@+id/textView7"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:text="@string/stats_total"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+            <TableLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp">
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_marginEnd="50dp"
+                        android:text="@string/stats_uploaded" />
+
+                    <TextView
+                        android:id="@+id/stats_total_uploaded"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end" />
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_downloaded" />
+
+                    <TextView
+                        android:id="@+id/stats_total_downloaded"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="end" />
+                </TableRow>
+            </TableLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:text="@string/stats_current_session"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="15dp">
+
+                <TableRow
+                    android:layout_width="fill_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_marginEnd="50dp"
+                        android:text="@string/stats_uploaded" />
+
+                    <TextView
+                        android:id="@+id/stats_session_uploaded"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end" />
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/stats_downloaded" />
+
+                    <TextView
+                        android:id="@+id/stats_session_downloaded"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="end" />
+                </TableRow>
+            </TableLayout>
+
+
+        </LinearLayout>
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="@{loadingInProgress ? View.VISIBLE : View.GONE}" />
+    </FrameLayout>
+
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="action_set_location">Set location</string>
     <string name="action_rename">Rename</string>
     <string name="action_share_magnet">Share Magnet Link</string>
+    <string name="action_open_stats">Statistics</string>
 
     <!-- Filters -->
     <string name="filters">Filters</string>
@@ -315,5 +316,10 @@
     </plurals>
 
     <string name="notification_channel_name">Torrent Downloading Finished</string>
+
+    <string name="stats_current_session">Current Session</string>
+    <string name="stats_total">Total</string>
+    <string name="stats_uploaded">Uploaded</string>
+    <string name="stats_downloaded">Downloaded</string>
 
 </resources>


### PR DESCRIPTION
This adds a small initial implementation of the stats page similar to that in transmission-web



![Ktn4UCsWRA6WO8U7eZz-aQ](https://github.com/user-attachments/assets/96ca8fd7-17cd-4fa9-bd8e-ec7c828de584)

This is a first contribution to an android/non-flutter project for me, so there may be some silly mistake :eyes: 
